### PR TITLE
elm 0.18 - type_

### DIFF
--- a/lib/html-to-elm.js
+++ b/lib/html-to-elm.js
@@ -42,7 +42,7 @@ function convertHtml(input) {
       // Get all attributes
       let attrs = Object.keys(attribs).map((attrKey) => {
         if (attrKey === 'type') {
-          attrKey = 'type\'';
+          attrKey = 'type_';
         }
         return attrKey + ' "' + attribs[attrKey] + '"';
       });

--- a/spec/html-to-elm-spec.js
+++ b/spec/html-to-elm-spec.js
@@ -62,7 +62,7 @@ describe('HtmlToElm', () => {
       '  , section\n' +
       '    [ id "main" ]\n' +
       '    [ input\n' +
-      '      [ name "toggle", id "toggle-all", type\' "undefined" ]\n' +
+      '      [ name "toggle", id "toggle-all", type_ "undefined" ]\n' +
       '      []\n' +
       '    , label\n' +
       '      [ for "toggle-all" ]\n' +


### PR DESCRIPTION
No more primes in variable names, Html.Attributes type' was renamed to type_